### PR TITLE
Fix the default value of "shift" property described in the specification

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -389,7 +389,7 @@ The **Loop Animation** must have a "style" property, and the value of this prope
 - *blink*: The **Element** blinks changing its opacity from 1 to 0. 
 - *wiggle*: The **Element** rotates left and right, where the "delta" property specifies the angree in degree (the default is 15)
 - *spin*: The **Element** spins, where the "clockwise" property (boolean) specifies the direction, the default is true. 
-- *shift*: The **Element** shift to the specified direction where the "direction" property specifies the direction ("n", "s", "e" or "w", the default is "n"). Use it with the "tiling" property.
+- *shift*: The **Element** shift to the specified direction where the "direction" property specifies the direction ("n", "s", "e" or "w", the default is "s"). Use it with the "tiling" property.
 - *path*: The **Element** performs path animation, where the "path" property specifies a collection of **Paths**. 
 - *sprite*: The **Element** performs a sprite animation. 
  


### PR DESCRIPTION
The default value is described as "n" in the spec, but implemented as "s". It's been confirmed the implementation is the correct one.
