### PR TITLE
Add version property to Document

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -90,6 +90,7 @@ When the user opens this document with a Swipe viewer, the user will see only th
 ### Document Properties
 
 - **type** (String): This must be "net.swipe.swipe" for a Swipe document
+- **version** (String): Version of the Swipe language specification used in the document
 - **title** (String): Title of the document, optional
 - **bc** (Color): Background color, default is *darkGray*
 - **dimension** ([Int, Int]): Dimension of the document, default is [320, 568]

--- a/core/SwipeBook.swift
+++ b/core/SwipeBook.swift
@@ -48,6 +48,13 @@ class SwipeBook: NSObject, SwipePageDelegate {
         return self.langs
     }
     
+    private (set) lazy var version:String? = {
+        if let version = self.bookInfo["version"] as? String {
+            return version
+        }
+        return nil
+    }()
+    
     lazy var title:String? = {
         if let title = self.bookInfo["title"] as? String {
             return title


### PR DESCRIPTION
Added `version` property to Document. It's main purpose is to convert a document described in an older specification to newer one.

In its implementation, `version` property of Document returns `nil` if not specified. (It was possible to return the version taken from `CFBundleShortVersionString`, but I thought returning `nil` was clearer to see no version was specified in the document.)

Version numbers should follow semantic versioning after v1.0.0. 
