### PR TITLE
Support font name (#29)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -256,6 +256,7 @@ An **Element** is a visible entity on a **Page**. It occupies a specified rectan
 - **text** (String, [langId:String] or ["ref":StringId]): Text to display
   - **textAlign** (String): Text alignment, *center* (default), *left* or *right*
   - **fontSize** (Float or Percent): Font size
+  - **fontName** (String or [String]): Font name or names (the first name existing in the system is used)
   - **textColor** (Color): Color of the text, animatable
 - **img** (URL): Image to display, animatable
 - **mask** (URL): Image mask (PNG with the alpha channel)

--- a/core/SwipeElement.swift
+++ b/core/SwipeElement.swift
@@ -1241,18 +1241,23 @@ class SwipeElement:NSObject {
                 processAlignment(alignment)
             }
         }
-        let fontSize:CGFloat = {
-            var ret = 20.0 / 480.0 * dimension.height // default
-            if let fontSize = info["fontSize"] as? CGFloat {
-                ret = fontSize
-            } else if let fontSize = info["fontSize"] as? String {
-                ret = SwipeParser.parsePercent(fontSize, full: dimension.height, defaultValue: ret)
+        let fontSize: CGFloat = {
+            let defaultSize = 20.0 / 480.0 * dimension.height
+            let size = SwipeParser.parseFontSize(info, full: dimension.height, defaultValue: defaultSize, markdown: false)
+            return round(size * scale.height)
+        }()
+        let fontNames = SwipeParser.parseFontName(info, markdown: false)
+        let font: UIFont = {
+            for fontName in fontNames {
+                if let font = UIFont(name: fontName, size: fontSize) {
+                    return font
+                }
             }
-            return round(ret * scale.height)
+            return UIFont(name: "Helvetica", size: fontSize)!
         }()
 
         let attr:[String:AnyObject] = [
-            NSFontAttributeName:UIFont(name: "Helvetica", size: fontSize)!,
+            NSFontAttributeName:font,
             NSForegroundColorAttributeName:UIColor(CGColor: SwipeParser.parseColor(info["textColor"], defaultColor: UIColor.blackColor().CGColor)),
             NSParagraphStyleAttributeName:paragraphStyle]
         let textStorage = NSTextStorage(string: text, attributes: attr)

--- a/core/SwipeParser.swift
+++ b/core/SwipeParser.swift
@@ -295,27 +295,38 @@ class SwipeParser {
     }
     
     static func parseFont(value:AnyObject?, scale:CGSize, full:CGFloat) -> UIFont {
-        var fontSize = CGFloat(20)
-        var fontNames = [String]()
-        if let info = value as? [String:AnyObject] {
-            if let sizeValue = info["size"] as? CGFloat {
-                fontSize = sizeValue
-            } else if let percent = info["size"] as? String {
-                fontSize = SwipeParser.parsePercent(percent, full: full, defaultValue: 20)
-            }
-            
-            if let name = info["name"] as? String {
-                fontNames = [name]
-            } else if let names = info["name"] as? [String] {
-                fontNames = names
-            }
-        }
+        let fontSize = parseFontSize(value, full: full, defaultValue: 20, markdown: true)
+        let fontNames = parseFontName(value, markdown: true)
         for name in fontNames {
             if let font = UIFont(name: name, size: fontSize * scale.height) {
                 return font
             }
         }
         return UIFont.systemFontOfSize(fontSize * scale.height)
+    }
+    
+    static func parseFontSize(value:AnyObject?, full:CGFloat, defaultValue:CGFloat, markdown:Bool) -> CGFloat {
+        let key = markdown ? "size" : "fontSize"
+        if let info = value as? [String:AnyObject] {
+            if let sizeValue = info[key] as? CGFloat {
+                return sizeValue
+            } else if let percent = info[key] as? String {
+                return SwipeParser.parsePercent(percent, full: full, defaultValue: defaultValue)
+            }
+        }
+        return defaultValue
+    }
+    
+    static func parseFontName(value:AnyObject?, markdown:Bool) -> [String] {
+        let key = markdown ? "name" : "fontName"
+        if let info = value as? [String:AnyObject] {
+            if let name = info[key] as? String {
+                return [name]
+            } else if let names = info[key] as? [String] {
+                return names
+            }
+        }
+        return []
     }
     
     static func parseShadow(value:AnyObject?, scale:CGSize) -> NSShadow {


### PR DESCRIPTION
Supported font name in an element as implementation of Issue #29. I chose the pattern A, adding `fontName` property under `text` property, described in the issue.
