### PR TITLE
Fix the thread to invoke completion progress of exportAsMovie method

### DIFF
--- a/browser/SwipeExporter.swift
+++ b/browser/SwipeExporter.swift
@@ -145,7 +145,9 @@ class SwipeExporter: NSObject {
                     input.markAsFinished()
                     print("SwipeExporter: finishWritingWithCompletionHandler")
                     writer.finishWritingWithCompletionHandler({
-                        progress(complete: true, error: nil)
+                        dispatch_async(dispatch_get_main_queue()) {
+                            progress(complete: true, error: nil)
+                        }
                     })
                 }
             }


### PR DESCRIPTION
Only the completion progress is executed in a background thread. It should run in the main thread as the other progress events in `exportAsMovie` do.
