### PR TITLE
visibility flag

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -245,6 +245,7 @@ An **Element** is a visible entity on a **Page**. It occupies a specified rectan
 ### Element properties
 
 - **id** (String): the element identifier in the associated **ElementTemplate** at the same nesting level
+- **visible** (Bool): the visibility of the element, defalult is true, not animatable.
 - **template** (String): the name of the **ElementTemplate** to inherit properties from
 - **x** (Float or Percent): x-position of the left-top corner of element, default is 0
 - **y** (Float or Percent): y-position of the left-top corner of the element, default is 0

--- a/core/SwipeElement.swift
+++ b/core/SwipeElement.swift
@@ -737,6 +737,10 @@ class SwipeElement: SwipeView, SwipeViewDelegate {
         
         layer.opacity = SwipeParser.parseFloat(info["opacity"])
         
+        if let visible = info["visible"] as? Bool where !visible {
+            layer.opacity = 0.0
+        }
+        
         if let to = info["to"] as? [String:AnyObject] {
             let start, duration:Double
             if let timing = to["timing"] as? [Double]


### PR DESCRIPTION
Adding the "visibility" flag to Element a as non-animatable property. This allows the authoring tool to turn on/off the visibility of each element without affecting the opacity property, which is animatable. 
