### PR TITLE
Clear a selected row of SwipeTableViewController when a SwipeBrowser is closed

### DIFF
--- a/browser/SwipeTableViewController.swift
+++ b/browser/SwipeTableViewController.swift
@@ -86,6 +86,14 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
             }
         }
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if let selectedIndexPath = tableView.indexPathForSelectedRow {
+            tableView.deselectRow(at: selectedIndexPath, animated: true)
+        }
+    }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()


### PR DESCRIPTION
Added the same behavior as UITableViewController did with `clearsSelectionOnViewWillAppear` option.
https://developer.apple.com/reference/uikit/uitableviewcontroller/1614758-clearsselectiononviewwillappear

**BEFORE:** A row is kept selected even after a SwipeBrowser is closed.
![before-fix](https://cloud.githubusercontent.com/assets/965994/20751375/c0076ff4-b73e-11e6-86ba-43e6cfb266fb.gif)

**AFTER:** A row is deselected automatically after a SwipeBrowser is closed.
![after-fix](https://cloud.githubusercontent.com/assets/965994/20751355/a4cb5e4e-b73e-11e6-8dbf-18e269d5eab6.gif)



