### PR TITLE
Added subtitles to "net.swipe.list" type table view

### DIFF
--- a/browser/SwipeTableViewController.swift
+++ b/browser/SwipeTableViewController.swift
@@ -170,18 +170,22 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = dequeueCell()
-
-        // Configure the cell...
         let section = self.sections[indexPath.section]
         guard let items = section["items"] as? [[String:Any]] else {
-            return cell
+            return dequeueCell(style: .default)
         }
         let item = items[indexPath.row]
+        let text = item["text"] as? String
+        let cell = dequeueCell(style: text == nil ? .default : .subtitle)
+
+        // Configure the cell...
         if let title = item["title"] as? String {
             cell.textLabel!.text = title
         } else if let url = item["url"] as? String {
             cell.textLabel!.text = url
+        }
+        if let text = text {
+            cell.detailTextLabel!.text = text
         }
         if let icon = item["icon"] as? String,
             let url = URL.url(icon, baseURL: self.url),
@@ -209,13 +213,17 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
         return section["title"] as? String
     }
     
-    private func dequeueCell() -> UITableViewCell {
-        if let cell = tableView.dequeueReusableCell(withIdentifier: "foo") {
+    private static let cellIdentifiers = [UITableViewCellStyle.default: "default", .subtitle: "subtitle"] // value1 and value2 styles are not supported yet.
+    
+    private func dequeueCell(style: UITableViewCellStyle) -> UITableViewCell {
+        let identifier = SwipeTableViewController.cellIdentifiers[style]!
+        if let cell = tableView.dequeueReusableCell(withIdentifier: identifier) {
             cell.textLabel?.text = nil
+            cell.detailTextLabel?.text = nil
             cell.imageView?.image = nil
             return cell
         } else {
-            return UITableViewCell(style: .default, reuseIdentifier: "foo")
+            return UITableViewCell(style: style, reuseIdentifier: identifier)
         }
     }
 

--- a/browser/SwipeTableViewController.swift
+++ b/browser/SwipeTableViewController.swift
@@ -170,7 +170,7 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell(style: UITableViewCellStyle.default, reuseIdentifier: "foo")
+        let cell = dequeueCell()
 
         // Configure the cell...
         let section = self.sections[indexPath.section]
@@ -207,6 +207,16 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         let section = self.sections[section]
         return section["title"] as? String
+    }
+    
+    private func dequeueCell() -> UITableViewCell {
+        if let cell = tableView.dequeueReusableCell(withIdentifier: "foo") {
+            cell.textLabel?.text = nil
+            cell.imageView?.image = nil
+            return cell
+        } else {
+            return UITableViewCell(style: .default, reuseIdentifier: "foo")
+        }
     }
 
     func tapped() {

--- a/sample/script/index.swipe
+++ b/sample/script/index.swipe
@@ -17,8 +17,8 @@
         { "url":"list.swipe", "title":"List", "icon":"Icon-180.png" },
         { "url":"network.swipe", "title":"Network", "icon":"Icon-180.png" },
         { "url":"details_index.swipe", "title":"Property Details", "icon":"more.png" },
-        { "url":"http://www.swipe.net/index.swipe", "title":"More ...", "icon":"more.png" },
-        { "url":"http://satoshi.blogs.com/swipe/index2.swipe", "title":"More 2...", "icon":"more.png" },
+        { "url":"http://www.swipe.net/index.swipe", "title":"More...", "text":"Load a list from a remote host", "icon":"more.png" },
+        { "url":"http://satoshi.blogs.com/swipe/index2.swipe", "title":"More 2...", "text":"Load a list from a remote host", "icon":"more.png" },
         { "url":"tv_index.swipe", "title":"TV", "icon":"more.png" },
         { "url":"https://raw.githubusercontent.com/swipe-org/swipe-sample/master/index.swipe", "title":"Test Cases", "icon":"Icon-180.png" },
         { "url":"https://raw.githubusercontent.com/swipe-org/swipe-sample/staging/index.swipe", "title":"Test Cases (Staging)", "icon":"Icon-180.png" }


### PR DESCRIPTION
I added `text` property to "net.swipe.list" type item to display the text value as a subtitle.

<img width="40%" src="https://cloud.githubusercontent.com/assets/965994/21104050/65adc59c-c0c8-11e6-98ec-1e08c92caa80.png">

Before this change, I cleaned up data source implementation to reuse table view cells (fed1292).