### PR TITLE
Reload table view data and update row height of SwipeTableViewController regardless of method call timings

### DIFF
--- a/browser/SwipeTableViewController.swift
+++ b/browser/SwipeTableViewController.swift
@@ -65,11 +65,12 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
         } else {
             throw SwipeError.invalidDocument
         }
+        _ = self.view // Make sure the view and subviews (tableView) are loaded from xib.
+        updateRowHeight()
         
         self.prefetcher.start { (completed:Bool, _:[URL], _:[NSError]) -> Void in
             if completed {
                 MyLog("SWTable prefetch complete", level:1)
-                _ = self.view // Make sure the view and subviews (tableView) are loaded from xib.
                 self.prefetching = false
                 self.tableView.reloadData()
             }
@@ -98,7 +99,10 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        
+        updateRowHeight()
+    }
+    
+    private func updateRowHeight() {
         let size = self.tableView.bounds.size
         if let value = document?["rowHeight"] as? CGFloat {
             self.tableView.rowHeight = value

--- a/browser/SwipeTableViewController.swift
+++ b/browser/SwipeTableViewController.swift
@@ -65,7 +65,16 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
         } else {
             throw SwipeError.invalidDocument
         }
-        callback(1.0, nil)
+        
+        self.prefetcher.start { (completed:Bool, _:[URL], _:[NSError]) -> Void in
+            if completed {
+                MyLog("SWTable prefetch complete", level:1)
+                _ = self.view // Make sure the view and subviews (tableView) are loaded from xib.
+                self.prefetching = false
+                self.tableView.reloadData()
+            }
+            callback(self.prefetcher.progress, nil)
+        }
     }
 
     override func viewDidLoad() {
@@ -76,14 +85,6 @@ class SwipeTableViewController: UIViewController, UITableViewDelegate, UITableVi
             effectView.frame = imageView.frame
             effectView.autoresizingMask = UIViewAutoresizing([.flexibleWidth, .flexibleHeight])
             imageView.addSubview(effectView)
-        }
-
-        self.prefetcher.start { (completed:Bool, _:[URL], _:[NSError]) -> Void in
-            if completed {
-                MyLog("SWTable prefetch complete", level:1)
-                self.prefetching = false
-                self.tableView.reloadData()
-            }
         }
     }
     


### PR DESCRIPTION
Modified SwipeTableViewController to embed it in a tab bar controller of an app. The problem to use it out of SwipeBrowser was that timings of `loadDocument` call against `viewDidLoad` and `viewDidLayoutSubviews` are different from the case when it is displayed by SwipeBrowser. To fix the problem, the following two changes have been applied.

- Start prefetcher and reload tableView of SwipeTableViewController properly regardless of the timings of loadDocument and viewDidLoad methods (b7995fe)
- Update rowHeight of SwipeTableViewController properly regardless of the timings of loadDocument and viewDidLayoutSubviews methods (baca809)