### PR TITLE
Fix SwipeVideoController's issue in pausing when duration is 0

### DIFF
--- a/sample/sample/SwipeVideoController.swift
+++ b/sample/sample/SwipeVideoController.swift
@@ -211,6 +211,8 @@ extension SwipeVideoController: SwipeDocumentViewer {
                         videoPlayer.pause()
                         self?.removeObserver()
                     }
+                } else {
+                    videoPlayer.pause()
                 }
             }
             


### PR DESCRIPTION
It fails to pause the video even when the duration is set to 0 in a case the .swipe file is like the following and the page is moved from the 1st to the next while the movie is still playing:
```json
{
  "type":"net.swipe.video",
  "dimension":[1024, 1366],
  "video":"test.mov",
  "pages":[{
    "start":0.0,
    "duration":60.0
  }, {
    "start":60.0,
    "duration":0.0
  }]
}
```