### PR TITLE
Added multilingual support to "net.swipe.list" type document

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1062,3 +1062,84 @@ Example:
 }
 
 ```
+
+## 17. List Type Document
+
+A list type document is a list of data to display in a table view. It can be used as an index file to list and link to Swipe documents.
+
+### Document Properties
+
+A list **Document** is a UTF8 JSON file, which consists of a collection of either **Items** or **Sections**. The items can be listed under **items** property in the document level directly if the document has only a section. If the document has multiple sections, items must be listed in each section under **sections** property.
+
+- **type** (String): This must be "net.swipe.list" for a list document.
+- **title** (String): Title of the document, optional.
+- **rowHeight** (Float or Percent): Absolute value of row height in points, or relative value to table view height. Default is the system default row height.
+- **sections** ([Section,...]): List sections. Either **sections** or **items** property can exist in the document level.
+- **items** ([Item,...]): List items. Either **sections** or **items** property can exist in the document level.
+- **strings** ([StringId:[LangId:String]]): String resources.
+- **languages** ({"id":LangId, "title":String},...): Languages to display via the "Lang." button in the Swipe viewer.
+
+### Section Properties
+
+A **Section** is a collection of **Items** to group them.
+
+- **title** (String, [langId:String] or ["ref":StringId]): Title for the section header.
+- **items** ([Item,...]): List items.
+
+### Item Properties
+
+An **Item** is an entity for a table row.
+
+- **url** (String): Absolute or relative URL to a Swipe document or list file.
+- **title** (String, [langId:String] or ["ref":StringId]): Title of the item.
+- **text** (String, [langId:String] or ["ref":StringId]): Text of the item to display as a subtitle, optional.
+- **icon** (String): Absolute or relative URL to an icon image file.
+
+Example for a single section:
+```
+{
+    "type":"net.swipe.list",
+    "rowHeight":50.0,
+    "items":[
+        { "url":"a.swipe", "title":"A", "text":"Subtitle A", "icon":"a.png" },
+        { "url":"b.swipe", "title":"B", "text":"Subtitle B", "icon":"b.png" }
+    ]
+}
+```
+
+Example for multiple sections with multilingual support:
+```
+{
+    "type":"net.swipe.list",
+    "rowHeight":"10%",
+    "languages":[
+        {"id": "en", "title": "English"},
+        {"id": "de", "title": "German"}
+    ],
+    "strings": {
+        "anim": {"en":"Animation", "de": "Animation"},
+        "trans": {"en":"Transition", "de": "Übergang"},
+        "loop": {"en":"Loop", "de": "Schleife"}
+    },
+    "sections":[
+        {
+            "title":{ "ref":"anim" },
+            "items":[
+                { "url":"t.swipe", "title":{ "ref":"trans" }, "icon":"t.png" },
+                { "url":"l.swipe", "title":{ "ref":"loop" }, "icon":"l.png" }
+            ]
+        },
+        {
+            "title":{ "en":"Appearance", "de":"Aussehen" },
+            "items":[
+                {
+                    "url":"c.swipe",
+                    "title":{ "en":"Color", "de":"Farbe" },
+                    "text":{ "en":"Subtitle", "de":"Untertitel" },
+                    "icon":"c.png"
+                }
+            ]
+        }
+    ]
+}
+```

--- a/browser/SwipeBrowser.swift
+++ b/browser/SwipeBrowser.swift
@@ -450,7 +450,9 @@ class SwipeBrowser: UIViewController, SwipeDocumentViewerDelegate {
                     //print("SwipeB language selected \(langId)")
                     self.documentViewer?.reloadWithLanguageId(langId)
 #if os(iOS)
-                    self.hideUI()
+                    if let documentViewer = self.documentViewer, documentViewer.hideUI() {
+                        self.hideUI()
+                    }
 #endif
                 }))
             }

--- a/core/SwipeParser.swift
+++ b/core/SwipeParser.swift
@@ -372,4 +372,27 @@ class SwipeParser {
         }
         return nil
     }
+
+    static func preferredLangId(in languages: [[String : Any]]) -> String? {
+        // 1st, find a lang id matching system language.
+        // A lang id can be in "en-US", "en", "zh-Hans-CN" or "zh-Hans" formats (with/without a country code).
+        // "en-US" or "zh-Hans-CN" formats with a country code have higher priority to match than "en" or "zh-Hans" without a country code.
+        if let systemLanguage = NSLocale.preferredLanguages.first?.components(separatedBy: "-") {
+            for rangeEnd in systemLanguage.indices.reversed() {
+                let langId = systemLanguage[0...rangeEnd].joined(separator: "-")
+                if languages.contains(where: { $0["id"] as? String == langId }) {
+                    return langId
+                }
+            }
+        }
+        // 2nd, use the default lang id ("*") if no lang id matches, and the default id exists.
+        if languages.contains(where: { $0["id"] as? String == "*" }) {
+            return "*"
+        }
+        // At last, use the first lang id in the language list if still no lang id is specified.
+        if let langId = languages.first?["id"] as? String {
+            return langId
+        }
+        return nil
+    }
 }

--- a/core/SwipeViewController.swift
+++ b/core/SwipeViewController.swift
@@ -91,7 +91,7 @@ class SwipeViewController: UIViewController, UIScrollViewDelegate, SwipeDocument
         self.book = SwipeBook(bookInfo: document, url: url, delegate: self)
 
         if let languages = self.book.languages(),
-           let langId = preferredLangId(in: languages) {
+           let langId = SwipeParser.preferredLangId(in: languages) {
             self.book.langId = langId
         }
 
@@ -118,29 +118,6 @@ class SwipeViewController: UIViewController, UIScrollViewDelegate, SwipeDocument
         }
     }
     
-    private func preferredLangId(in languages: [[String : Any]]) -> String? {
-        // 1st, find a lang id matching system language.
-        // A lang id can be in "en-US", "en", "zh-Hans-CN" or "zh-Hans" formats (with/without a country code).
-        // "en-US" or "zh-Hans-CN" formats with a country code have higher priority to match than "en" or "zh-Hans" without a country code.
-        if let systemLanguage = NSLocale.preferredLanguages.first?.components(separatedBy: "-") {
-            for rangeEnd in systemLanguage.indices.reversed() {
-                let langId = systemLanguage[0...rangeEnd].joined(separator: "-")
-                if languages.contains(where: { $0["id"] as? String == langId }) {
-                    return langId
-                }
-            }
-        }
-        // 2nd, use the default lang id ("*") if no lang id matches, and the default id exists.
-        if languages.contains(where: { $0["id"] as? String == "*" }) {
-            return "*"
-        }
-        // At last, use the first lang id in the language list if still no lang id is specified.
-        if let langId = languages.first?["id"] as? String {
-            return langId
-        }
-        return nil
-    }
-
     // <SwipeDocumentViewer> method
     func setDelegate(_ delegate:SwipeDocumentViewerDelegate) {
         self.delegate = delegate

--- a/sample/sample.xcodeproj/project.pbxproj
+++ b/sample/sample.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		98085FD01DDC0935008AA95A /* SwipeBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38FB4AB1D702D5200D6DF0B /* SwipeBrowser.swift */; };
 		98085FD11DDC0935008AA95A /* SwipeExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38FB4AC1D702D5200D6DF0B /* SwipeExporter.swift */; };
 		98085FD21DDC0935008AA95A /* SwipeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F38FB4AD1D702D5200D6DF0B /* SwipeTableViewController.swift */; };
+		986DFFF71E160906002AD77B /* multilingual_strings.swipe in Resources */ = {isa = PBXBuildFile; fileRef = 98C3632F1CD97B60005E7071 /* multilingual_strings.swipe */; };
 		9871A4E91CC51C88006DE5C6 /* loop_animation.swipe in Resources */ = {isa = PBXBuildFile; fileRef = 9871A4E81CC51C88006DE5C6 /* loop_animation.swipe */; };
 		9871A4EA1CC51C88006DE5C6 /* loop_animation.swipe in Resources */ = {isa = PBXBuildFile; fileRef = 9871A4E81CC51C88006DE5C6 /* loop_animation.swipe */; };
 		98C363301CD97B60005E7071 /* multilingual_strings.swipe in Resources */ = {isa = PBXBuildFile; fileRef = 98C3632F1CD97B60005E7071 /* multilingual_strings.swipe */; };
@@ -902,6 +903,7 @@
 				9871A4EA1CC51C88006DE5C6 /* loop_animation.swipe in Resources */,
 				74DD7FAC1BDD3E770042BB9D /* nasa013.jpg in Resources */,
 				74DD7FE31BDFE33F0042BB9D /* chara_walk.png in Resources */,
+				986DFFF71E160906002AD77B /* multilingual_strings.swipe in Resources */,
 				980482031CB8B51C0068F18C /* SwipeBrowser.xib in Resources */,
 				740FD4881BE2D7A700C2D91D /* SwipeTableViewController.xib in Resources */,
 				74DD7F9A1BDD3E770042BB9D /* nasa004.jpg in Resources */,

--- a/sample/script/details/details_index.swipe
+++ b/sample/script/details/details_index.swipe
@@ -1,9 +1,33 @@
 {
     "type":"net.swipe.list",
     "rowHeight":"10%",
-    "items":[
-        { "url":"transition_animation.swipe", "title":"Transition Animation", "icon":"more.png" },
-        { "url":"loop_animation.swipe", "title":"Loop Animation", "icon":"more.png" },
-        { "url":"multilingual_strings.swipe", "title":"Multilingual Strings", "icon":"more.png" },
+    "languages":[
+        {"id": "en", "title": "English"},
+        {"id": "de", "title": "German"}
+    ],
+    "strings": {
+        "anim": {"en":"Animation", "de": "Animation"},
+        "trans": {"en":"Transition Animation", "de": "Übergangsanimation"},
+        "loop": {"en":"Loop Animation", "de": "Schleifenanimation"}
+    },
+    "sections":[
+        {
+            "title":{ "ref":"anim" },
+            "items":[
+                { "url":"transition_animation.swipe", "title":{ "ref":"trans" }, "icon":"more.png" },
+                { "url":"loop_animation.swipe", "title":{ "ref":"loop" }, "icon":"more.png" }
+            ]
+        },
+        {
+            "title":{ "en":"Language", "de":"Sprache" },
+            "items":[
+                {
+                    "url":"multilingual_strings.swipe",
+                    "title":{ "en":"Multilingual Strings", "de":"Mehrsprachige Strings" },
+                    "text":{ "en":"This example has translation", "de":"Dieses beispiel hat übersetzung" },
+                    "icon":"more.png"
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
I added multilingual support to "net.swipe.list" type document in the same way as normal Swipe document supports.

### Main changes

- Cleaned up to move `preferredLangId` function from SwipeViewController to SwipeParser to use it in SwipeTableViewController too. The static function can be defined anywhere technically, but I chose SwipeParser because its `localizedString` had a kind of similar functionality. (3fdce1b)
- Implemented the multilingual support. (899107d)
- Fixed a minor issue caused by assumption taking only "net.swipe.swipe" type document. (e2b6f3b)

### Updates of a sample and document

- Updated "details_index.swipe" file to add an example of multilingual support. It is accessible from "Property Details" menu of the main index if you run the sample project. (fde2736)
- Updated the spec document to describe "net.swipe.list" type document. (ec7a0f5)

### What I did not

I did not add multilingual support to document `title` property because the property in "net.swipe.swipe" type document is not localizable. The document title localization may be implemented for both "net.swipe.swipe" and "net.swipe.list" type documents in another pull request.